### PR TITLE
Le cambié el scrollbar no sólo a las Políticas sino también a todas l…

### DIFF
--- a/legal.css
+++ b/legal.css
@@ -5,3 +5,25 @@
     width: 50%;
   }
   
+  * {
+    scrollbar-width: thin;
+    scrollbar-color: #ffffff #f2d5a0;
+  }
+  
+  /* Works on Chrome/Edge/Safari */
+  *::-webkit-scrollbar {
+    width: 12px;
+  }
+  *::-webkit-scrollbar-track {
+    background: #f2d5a0;
+  }
+  *::-webkit-scrollbar-thumb {
+    background-color: #ffffff;
+    border-radius: 20px;
+    border: 3px solid #f2d5a0;
+  }
+
+  .texto-politicas{
+    padding-left: 10px;
+    padding-right: 10px;
+  }

--- a/legal.css
+++ b/legal.css
@@ -1,29 +1,30 @@
 .long-text {
-    overflow: scroll;
-    width: 1200px;
-    height: 500px;
-    width: 50%;
-  }
-  
-  * {
-    scrollbar-width: thin;
-    scrollbar-color: #ffffff #f2d5a0;
-  }
-  
-  /* Works on Chrome/Edge/Safari */
-  *::-webkit-scrollbar {
-    width: 12px;
-  }
-  *::-webkit-scrollbar-track {
-    background: #f2d5a0;
-  }
-  *::-webkit-scrollbar-thumb {
-    background-color: #ffffff;
-    border-radius: 20px;
-    border: 3px solid #f2d5a0;
-  }
+  overflow: scroll;
+  width: 1200px;
+  height: 500px;
+  width: 50%;
+  overflow-x: hidden;
+}
 
-  .texto-politicas{
-    padding-left: 10px;
-    padding-right: 10px;
-  }
+* {
+  scrollbar-width: thin;
+  scrollbar-color: #ffffff #f2d5a0;
+}
+
+/* Works on Chrome/Edge/Safari */
+*::-webkit-scrollbar {
+  width: 12px;
+}
+*::-webkit-scrollbar-track {
+  background: #f2d5a0;
+}
+*::-webkit-scrollbar-thumb {
+  background-color: #ffffff;
+  border-radius: 20px;
+  border: 3px solid #f2d5a0;
+}
+
+.texto-politicas {
+  padding-left: 10px;
+  padding-right: 10px;
+}

--- a/politicas-privacidad.html
+++ b/politicas-privacidad.html
@@ -55,7 +55,7 @@
 
       <div class="long-text">
         <h2>Políticas de Privacidad</h2>
-        <p>
+        <p class="texto-politicas">
           Política de privacidad y tratamiento de datos personales
           <br /><br />
           Al acceder y navegar en la red de los portales de Solo Valencia, el


### PR DESCRIPTION
…as páginas. Le puse padding-right y -left al texto de las políticas para que no quedara tapado por la scrollbar: le agregué la clase texto-politicas al <p> y puse el estilo en legal.css (también se podía hacer agregándoselo a p, li{} del index pero no sé si afectaba algo de otra página).

--

Por cierto, toda el área del header (no sólo el logo) está clickeable para mandar a Home.No sé si es la idea.